### PR TITLE
more upstream fixes for CVE-2016-9602

### DIFF
--- a/hw/9pfs/virtio-9p-local.c
+++ b/hw/9pfs/virtio-9p-local.c
@@ -956,7 +956,7 @@ static int local_unlinkat_common(FsContext *ctx, int dirfd, const char *name,
         if (flags == AT_REMOVEDIR) {
             int fd;
 
-            fd = openat(dirfd, name, O_RDONLY | O_DIRECTORY | O_PATH);
+            fd = openat_dir(dirfd, name);
             if (fd == -1) {
                 goto err_out;
             }

--- a/hw/9pfs/virtio-9p-util.h
+++ b/hw/9pfs/virtio-9p-util.h
@@ -34,7 +34,8 @@ static inline int openat_dir(int dirfd, const char *name)
 #else
 #define OPENAT_DIR_O_PATH 0
 #endif
-    return openat(dirfd, name, O_DIRECTORY | O_RDONLY | OPENAT_DIR_O_PATH);
+    return openat(dirfd, name,
+                  O_DIRECTORY | O_RDONLY | O_NOFOLLOW | OPENAT_DIR_O_PATH);
 }
 
 static inline int openat_file(int dirfd, const char *name, int flags,

--- a/hw/9pfs/virtio-9p-util.h
+++ b/hw/9pfs/virtio-9p-util.h
@@ -29,7 +29,12 @@ static inline void close_preserve_errno(int fd)
 
 static inline int openat_dir(int dirfd, const char *name)
 {
-    return openat(dirfd, name, O_DIRECTORY | O_RDONLY | O_PATH);
+#ifdef O_PATH
+#define OPENAT_DIR_O_PATH O_PATH
+#else
+#define OPENAT_DIR_O_PATH 0
+#endif
+    return openat(dirfd, name, O_DIRECTORY | O_RDONLY | OPENAT_DIR_O_PATH);
 }
 
 static inline int openat_file(int dirfd, const char *name, int flags,


### PR DESCRIPTION
upstream commit https://github.com/qemu/qemu/commit/b003fc0d8aa5e7060dbf7e5862b8013c73857c7f (9pfs: fix vulnerability in openat_dir() and local_unlinkat_common()) and https://github.com/qemu/qemu/commit/918112c02aff2bac4cb72dc2feba0cb05305813e (9pfs: fix O_PATH build break with older glibc versions)